### PR TITLE
Standalone services

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             'livetiming-analysis = livetiming.generate_analysis:main',
             'livetiming-directory = livetiming.orchestration.directory:main',
             'livetiming-dvr = livetiming.orchestration.dvr:main',
+            'livetiming-plugins = livetiming.service.plugins.__main__:main',
             'livetiming-recordings = livetiming.recording:main',
             'livetiming-recordings-index = livetiming.recording:update_recordings_index',
             'livetiming-rectool = livetiming.orchestration.rectool:main',

--- a/src/livetiming/analysis/__init__.py
+++ b/src/livetiming/analysis/__init__.py
@@ -113,6 +113,9 @@ class Analyser(object):
 
     @with_dc_lock
     def save_data_centre(self):
+        analysis_dir = os.environ.get("LIVETIMING_ANALYSIS_DIR", os.getcwd())
+        if not os.path.exists(analysis_dir):
+            os.mkdir(analysis_dir)
         start = time.time()
         with open(self._data_centre_file(), "wb") as data_dump_file:
             pickle.dump(self.data_centre, data_dump_file, pickle.HIGHEST_PROTOCOL)

--- a/src/livetiming/service/__init__.py
+++ b/src/livetiming/service/__init__.py
@@ -31,6 +31,7 @@ def parse_args(args=None):
     parser.add_argument('-H', '--hidden', action='store_true', help='Hide this service from the UI except by UUID access')
     parser.add_argument('-N', '--do-not-record', action='store_true', help='Tell the DVR not to keep the recording of this service')
     parser.add_argument('-m', '--masquerade', nargs='?', help='Masquerade as this service class')
+    parser.add_argument('--standalone', action='store_true', help='Run service in standalone configuration')
 
     return parser.parse_known_args(args)
 

--- a/src/livetiming/service/__init__.py
+++ b/src/livetiming/service/__init__.py
@@ -66,7 +66,7 @@ def main():
 
     with codecs.open(filepath, mode='a', encoding='utf-8') as logFile:
         level = "debug" if args.debug else "info"
-        if not args.verbose:  # log to file, not stdout
+        if not args.verbose and not args.standalone:  # log to file, not stdout
             txaio.start_logging(out=logFile, level=level)
 
         logger = Logger()

--- a/src/livetiming/service/__init__.py
+++ b/src/livetiming/service/__init__.py
@@ -59,8 +59,13 @@ def main():
 
     plugin_source = get_plugin_source()
 
+    log_dir = os.environ.get("LIVETIMING_LOG_DIR", os.getcwd())
+
+    if not os.path.exists(log_dir):
+        os.mkdir(log_dir)
+
     filepath = os.path.join(
-        os.environ.get("LIVETIMING_LOG_DIR", os.getcwd()),
+        log_dir,
         "{}.log".format(args.service_class)
     )
 

--- a/src/livetiming/service/plugins/__main__.py
+++ b/src/livetiming/service/plugins/__main__.py
@@ -1,0 +1,23 @@
+from livetiming.service import get_plugin_source
+
+import simplejson
+
+
+def main():
+    with get_plugin_source() as source:
+        plugins = list(
+            filter(
+                lambda p: p[0] != '_',
+                source.list_plugins()
+            )
+        )
+
+        plugin_stats = {
+            p: getattr(source.load_plugin(p), '__spec', {}) for p in plugins
+        }
+
+        print(simplejson.dumps(plugin_stats))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/livetiming/service/service.py
+++ b/src/livetiming/service/service.py
@@ -293,6 +293,10 @@ class BaseService(AbstractService, ManifestPublisher):
             LoopingCall(self.analyser._publish_pending).start(60)
             self.analyser.publish_all()
 
+        if 'LIVETIMING_ROUTER' not in os.environ:
+            self.log.info('LIVETIMING_ROUTER not set, forcing standalone mode.')
+            self.args.standalone = True
+
         if self.args.standalone:
             def report_port(port):
                 print(

--- a/src/livetiming/service/service.py
+++ b/src/livetiming/service/service.py
@@ -24,6 +24,7 @@ import copy
 import os
 import sentry_sdk
 import simplejson
+import sys
 import time
 
 
@@ -293,7 +294,12 @@ class BaseService(AbstractService, ManifestPublisher):
             self.analyser.publish_all()
 
         if self.args.standalone:
-            session = create_standalone_session(self)
+            def report_port(port):
+                print(
+                    'Standalone server for uuid:{} listening on port:{}'.format(self.uuid, port),
+                    file=sys.stderr
+                )
+            session = create_standalone_session(self, report_port)
             session.run()
         else:
             session_class = create_service_session(self)

--- a/src/livetiming/service/service.py
+++ b/src/livetiming/service/service.py
@@ -345,8 +345,12 @@ class BaseService(AbstractService, ManifestPublisher):
     def _saveState(self):
         self.log.debug("Saving state of {}".format(self.uuid))
 
+        state_dir = os.environ.get("LIVETIMING_STATE_DIR", os.getcwd())
+        if not os.path.exists(state_dir):
+            os.mkdir(state_dir)
+
         filepath = os.path.join(
-            os.environ.get("LIVETIMING_STATE_DIR", os.getcwd()),
+            state_dir,
             "{}.json".format(self.uuid)
         )
 

--- a/src/livetiming/service/standalone.py
+++ b/src/livetiming/service/standalone.py
@@ -1,0 +1,35 @@
+from autobahn.twisted.websocket import WebSocketServerProtocol, WebSocketServerFactory
+from twisted.internet import reactor
+
+import simplejson
+
+
+class StandaloneSession(object):
+    def __init__(self, protocol):
+        self._protocol = protocol
+
+    def run(self):
+        factory = WebSocketServerFactory()
+        factory.protocol = self._protocol
+
+        reactor.listenTCP(9000, factory)
+        reactor.run()
+
+
+def create_standalone_session(service):
+    class StandaloneServiceProtocol(WebSocketServerProtocol):
+
+        def onConnect(self, request):
+            service.set_publish(self.publish)
+
+        def onClose(self, wasClean, code, reason):
+            service.set_publish(None)
+
+        def publish(self, channel, message, *args, **kwargs):
+            payload = simplejson.dumps([
+                channel,
+                message
+            ])
+            self.sendMessage(payload.encode('utf-8'), False)
+
+    return StandaloneSession(StandaloneServiceProtocol)

--- a/src/livetiming/service/standalone.py
+++ b/src/livetiming/service/standalone.py
@@ -27,6 +27,7 @@ def create_standalone_session(service, port_callback=None):
 
         def onConnect(self, request):
             service.set_publish(self.publish)
+            service.publishManifest()
 
         def onClose(self, wasClean, code, reason):
             service.set_publish(None)

--- a/src/livetiming/service/standalone.py
+++ b/src/livetiming/service/standalone.py
@@ -2,21 +2,27 @@ from autobahn.twisted.websocket import WebSocketServerProtocol, WebSocketServerF
 from twisted.internet import reactor
 
 import simplejson
+import txaio
 
 
 class StandaloneSession(object):
-    def __init__(self, protocol):
+    def __init__(self, protocol, port_callback=None):
         self._protocol = protocol
+        self._port_callback = port_callback
 
     def run(self):
         factory = WebSocketServerFactory()
         factory.protocol = self._protocol
 
-        reactor.listenTCP(9000, factory)
+        listening_port = reactor.listenTCP(0, factory)
+        if self._port_callback:
+            self._port_callback(listening_port.getHost().port)
+
+        txaio.start_logging()
         reactor.run()
 
 
-def create_standalone_session(service):
+def create_standalone_session(service, port_callback=None):
     class StandaloneServiceProtocol(WebSocketServerProtocol):
 
         def onConnect(self, request):
@@ -32,4 +38,4 @@ def create_standalone_session(service):
             ])
             self.sendMessage(payload.encode('utf-8'), False)
 
-    return StandaloneSession(StandaloneServiceProtocol)
+    return StandaloneSession(StandaloneServiceProtocol, port_callback)


### PR DESCRIPTION
This PR creates "standalone" services that provide a local WebSocket server rather than connecting to the Timing71 network.

This mechanism is used by the desktop client to start and obtain data from locally-running services without the need to connect to the wider Timing71 network.

I've only really tested this with a single client at a time; multiple clients might work, or might all go horribly wrong...